### PR TITLE
Update psycopg2 to 2.9.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ django-cors-headers==3.1.1
 django-environ==0.4.5
 djangorestframework==3.11.2
 inflection==0.3.1
-psycopg2==2.7.1
+psycopg2==2.9.3 
 six==1.15.0


### PR DESCRIPTION
This PR updates psycopg2 to 2.9.3 to fix an issue with building on Python 3.8 using v2.7